### PR TITLE
TRITON-2481 Increase PAPI's MAX_VCPUS to 64

### DIFF
--- a/lib/validations.js
+++ b/lib/validations.js
@@ -6,7 +6,7 @@
 
 /*
  * Copyright 2019 Joyent, Inc.
- * Copryight 2025 MNX Cloud, Inc.
+ * Copyright 2025 MNX Cloud, Inc.
  */
 
 /*

--- a/lib/validations.js
+++ b/lib/validations.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2019 Joyent, Inc.
+ * Copryight 2025 MNX Cloud, Inc.
  */
 
 /*
@@ -66,7 +67,7 @@ var MIN_CPUCAP = 20;
 var MIN_LWPS = 250;
 var MIN_VCPUS = 1;
 
-var MAX_VCPUS = 48;
+var MAX_VCPUS = 64;
 var MAX_ZFSIO = 16383;
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sdc-papi",
   "description": "Packages API",
-  "version": "7.2.4",
+  "version": "7.2.5",
   "author": "MNX Cloud (mnx.io)",
   "private": true,
   "repository": {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2025 MNX Cloud, Inc.
  */
 
 /*
@@ -533,10 +534,10 @@ test('POST /packages (VCPUS exceeding MAX value)', function (t) {
         quota: 1024,
         max_swap: 256,
         cpu_cap: 350,
-        max_lwps: 2000,
+        max_lwps: 3000,
         zfs_io_priority: 100,
         'default': true,
-        vcpus: 50,
+        vcpus: 72,
         active: true,
         group: 'ramones',
         uuid: 'ebb58a8c-b77e-4559-bbf0-19ebd67973f0',
@@ -559,7 +560,7 @@ test('POST /packages (VCPUS exceeding MAX value)', function (t) {
         var expectedErrs = [ {
             field: 'vcpus',
             code: 'Invalid',
-            message: 'must be greater or equal to 1, and less or equal to 48'
+            message: 'must be greater or equal to 1, and less or equal to 64'
         }];
         t.deepEqual(err.body.errors, expectedErrs);
 


### PR DESCRIPTION
Needs serious testing, but in essence the changes are similar to TRITON-777.